### PR TITLE
Add RcppParallel cxxflags to makevars

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,7 @@
 CXX_STD = CXX11
 
 PKG_CXXFLAGS = -DRCPP_PARALLEL_USE_TBB=1 -O2 -DNDEBUG
+PKG_CXXFLAGS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::CxxFlags()")
 
 PKG_LIBS = $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" \
               -e "RcppParallel::RcppParallelLibs()") \


### PR DESCRIPTION
This PR adds RcppParallel's CXXFLAGS to your Makevars, which will be needed for compatibility with Windows ARM64